### PR TITLE
Refactor settings and fix security vulnerabilities

### DIFF
--- a/documents-service/settings/base.py
+++ b/documents-service/settings/base.py
@@ -165,10 +165,10 @@ MEDIA_URL = '/media/'
 
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
+AWS_DEFAULT_ACL = None
+AWS_S3_SECURE_URLS = True
 AWS_SECRET_ACCESS_KEY = os.getenv('AWS_ACCESS_KEY_SECRET')
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
-AWS_S3_SECURE_URLS = True
-AWS_DEFAULT_ACL = None
 
 # file storage options ['local','S3','gdrive','office365']
 # TODO: add integration for gdrive and office365

--- a/documents-service/settings/production.py
+++ b/documents-service/settings/production.py
@@ -25,10 +25,6 @@ try:
 except KeyError:
     ALLOWED_HOSTS = []
 
-# https://docs.djangoproject.com/en/1.11/ref/settings/#secure-proxy-ssl-header
-
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
 
 # Logging
 # https://docs.djangoproject.com/en/1.11/topics/logging/#configuring-logging
@@ -60,8 +56,3 @@ USE_X_FORWARDED_HOST = True if os.getenv('USE_X_FORWARDED_HOST') == 'True' \
 
 if os.getenv('USE_HTTPS') == 'True':
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-
-AWS_ACCESS_KEY_ID = os.getenv('AWS_ACCESS_KEY_ID')
-AWS_SECRET_ACCESS_KEY = os.getenv('AWS_ACCESS_KEY_SECRET')
-BOTO_S3_BUCKET = os.getenv('AWS_S3_BUCKET')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.0.5
+Django~=2.0.13
 git+https://github.com/Humanitec/django-oauth-toolkit-jwt@v0.5.2#egg=django-oauth-toolkit-jwt
 djangorestframework==3.8.2
 coreapi==2.3.3


### PR DESCRIPTION
- AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID are already in
base-settings
- BOTO_S3_BUCKET is not needed (tests are working without it)
- SECURE_PROXY_SSL_HEADER is doubled