### PR TITLE
update entrypoint to wait db

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+bash scripts/tcp-port-wait.sh $DATABASE_HOST $DATABASE_PORT
+
 echo $(date -u) " - Migrating"
 python manage.py migrate
 


### PR DESCRIPTION
# Purpose
We need to update entrypoint to wait for db. Otherwise, it doesn't run migrations when db is not there.

